### PR TITLE
UpdateTabIndicator so we dont get a scroll

### DIFF
--- a/src/UniversalDashboard.Materialize/Components/tabs.jsx
+++ b/src/UniversalDashboard.Materialize/Components/tabs.jsx
@@ -1,10 +1,12 @@
-import React, {Fragment} from 'react';
+import React, { Fragment } from 'react';
 import M from 'materialize-css';
 
 export default class TabContainer extends React.Component {
 
     componentDidMount() {
         M.Tabs.init(this.element);
+        var instance = M.Tabs.getInstance(this.element);
+        instance.updateTabIndicator();
     }
 
     renderTabHeaders() {
@@ -38,13 +40,13 @@ export default class TabContainer extends React.Component {
 
         return (
             <Fragment>
-            <div>
-              <ul className="tabs" ref={x => this.element = x}>
-                {headers}
-              </ul>
-            </div>
-            {content}
-          </Fragment>
+                <div>
+                    <ul className="tabs" ref={x => this.element = x}>
+                        {headers}
+                    </ul>
+                </div>
+                {content}
+            </Fragment>
 
         )
     }


### PR DESCRIPTION
Models have issues trying to figure out how wide they are so we need to tell materialize to update the tabIndicator so we dont get a scroll bar.
https://github.com/ironmansoftware/universal-dashboard/issues/1221